### PR TITLE
ports: exclude shadowsocks-rust on aarch64

### DIFF
--- a/config/25.1/ports.conf
+++ b/config/25.1/ports.conf
@@ -151,7 +151,7 @@ net/rsync					arm
 net/samplicator
 net/scapy
 net/shadowsocks-libev				arm
-net/shadowsocks-rust				arm
+net/shadowsocks-rust				arm,aarch64
 net/siproxd					arm
 net/sslh
 net/tayga					arm


### PR DESCRIPTION
Fails to build.

https://github.com/opnsense/plugins/issues/4662#issuecomment-2898196123